### PR TITLE
Switch to TryGetGlobalItem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,6 @@ Border.png
 glow.png
 glow2.png
 icon_ase.ase
+
+.gitignore
+*.sln

--- a/.gitignore
+++ b/.gitignore
@@ -352,6 +352,3 @@ Border.png
 glow.png
 glow2.png
 icon_ase.ase
-
-.gitignore
-*.sln

--- a/Content/Prefixes/Accessory/AccessoryPrefix.cs
+++ b/Content/Prefixes/Accessory/AccessoryPrefix.cs
@@ -21,13 +21,16 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Accessory {
         }
 
         public override void Apply(Item item) {
-            var gi = item.GetGlobalItem<AccessoryGlobalItem>();
-            gi.MaxMana = 0;
-            gi.ReducedAmmo = 0;
-            gi.MinionKnockback = 0;
-            gi.TileReach = 0;
-            gi.PickupRange = 0;
-            gi.MiningSpeed = 0;
+            bool gotItem = item.TryGetGlobalItem(out AccessoryGlobalItem gi);
+            if (gotItem)
+            {
+                gi.MaxMana = 0;
+                gi.ReducedAmmo = 0;
+                gi.MinionKnockback = 0;
+                gi.TileReach = 0;
+                gi.PickupRange = 0;
+                gi.MiningSpeed = 0;
+            }
         }
     }
 }

--- a/Content/Prefixes/Accessory/Bountiful.cs
+++ b/Content/Prefixes/Accessory/Bountiful.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Accessory {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<AccessoryGlobalItem>().ReducedAmmo = 0.2f;
+            bool gotItem = item.TryGetGlobalItem(out AccessoryGlobalItem gi);
+            if (gotItem)
+            {
+                gi.ReducedAmmo = 0.2f;
+            }
         }
     }
 }

--- a/Content/Prefixes/Accessory/Colossal.cs
+++ b/Content/Prefixes/Accessory/Colossal.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Accessory {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<AccessoryGlobalItem>().MinionKnockback = 1f;
+            bool gotItem = item.TryGetGlobalItem(out AccessoryGlobalItem gi);
+            if (gotItem)
+            {
+                gi.MinionKnockback = 1f;
+            }
         }
     }
 }

--- a/Content/Prefixes/Accessory/Extending.cs
+++ b/Content/Prefixes/Accessory/Extending.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Accessory {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<AccessoryGlobalItem>().TileReach = 2;
+            bool gotItem = item.TryGetGlobalItem(out AccessoryGlobalItem gi);
+            if (gotItem)
+            {
+                gi.TileReach = 2;
+            }
         }
     }
 }

--- a/Content/Prefixes/Accessory/Gravitating.cs
+++ b/Content/Prefixes/Accessory/Gravitating.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Accessory {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<AccessoryGlobalItem>().PickupRange = 4;
+            bool gotItem = item.TryGetGlobalItem(out AccessoryGlobalItem gi);
+            if (gotItem)
+            {
+                gi.PickupRange = 4;
+            }
         }
     }
 }

--- a/Content/Prefixes/Accessory/Plentiful.cs
+++ b/Content/Prefixes/Accessory/Plentiful.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Accessory {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<AccessoryGlobalItem>().ReducedAmmo = 0.1f;
+            bool gotItem = item.TryGetGlobalItem(out AccessoryGlobalItem gi);
+            if (gotItem)
+            {
+                gi.ReducedAmmo = 0.1f;
+            }
         }
     }
 }

--- a/Content/Prefixes/Accessory/Pulling.cs
+++ b/Content/Prefixes/Accessory/Pulling.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Accessory {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<AccessoryGlobalItem>().PickupRange = 2;
+            bool gotItem = item.TryGetGlobalItem(out AccessoryGlobalItem gi);
+            if (gotItem)
+            {
+                gi.PickupRange = 2;
+            }
         }
     }
 }

--- a/Content/Prefixes/Accessory/Reaching.cs
+++ b/Content/Prefixes/Accessory/Reaching.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Accessory {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<AccessoryGlobalItem>().TileReach = 1;
+            bool gotItem = item.TryGetGlobalItem(out AccessoryGlobalItem gi);
+            if (gotItem)
+            {
+                gi.TileReach = 1;
+            }
         }
     }
 }

--- a/Content/Prefixes/Accessory/Speedy.cs
+++ b/Content/Prefixes/Accessory/Speedy.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Accessory {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<AccessoryGlobalItem>().MiningSpeed = 0.05f;
+            bool gotItem = item.TryGetGlobalItem(out AccessoryGlobalItem gi);
+            if (gotItem)
+            {
+                gi.MiningSpeed = 0.05f;
+            }
         }
     }
 }

--- a/Content/Prefixes/Accessory/Spellbound.cs
+++ b/Content/Prefixes/Accessory/Spellbound.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Accessory {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<AccessoryGlobalItem>().MaxMana = 40;
+            bool gotItem = item.TryGetGlobalItem(out AccessoryGlobalItem gi);
+            if (gotItem)
+            {
+                gi.MaxMana = 40;
+            }
         }
     }
 }

--- a/Content/Prefixes/Accessory/Sturdy.cs
+++ b/Content/Prefixes/Accessory/Sturdy.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Accessory {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<AccessoryGlobalItem>().MinionKnockback = 0.5f;
+            bool gotItem = item.TryGetGlobalItem(out AccessoryGlobalItem gi);
+            if (gotItem)
+            {
+                gi.MinionKnockback = 0.5f;
+            }
         }
     }
 }

--- a/Content/Prefixes/Accessory/Turbo.cs
+++ b/Content/Prefixes/Accessory/Turbo.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Accessory {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<AccessoryGlobalItem>().MiningSpeed = 0.1f;
+            bool gotItem = item.TryGetGlobalItem(out AccessoryGlobalItem gi);
+            if (gotItem)
+            {
+                gi.MiningSpeed = 0.1f;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Accelerating.cs
+++ b/Content/Prefixes/Armor/Accelerating.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().RunSpeedBoost = 1.5f;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.RunSpeedBoost = 1.5f;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/ArmorPrefix.cs
+++ b/Content/Prefixes/Armor/ArmorPrefix.cs
@@ -19,18 +19,21 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
         }
 
         public override void Apply(Item item) {
-            var gi = item.GetGlobalItem<ArmorGlobalItem>();
-            gi.MaxHP = 0;
-            gi.CritDamage = 1f;
-            gi.Aggro = 0;
-            gi.LifeRegen = 0;
-            gi.JumpSpeedBoost = 0f;
-            gi.RunSpeedBoost = 1f;
-            gi.ArmorPenetration = 0;
-            gi.MinionSlots = 0;
-            gi.SentrySlots = 0;
-            gi.DamageReduction = 0;
-            gi.FlightTime = 0;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.MaxHP = 0;
+                gi.CritDamage = 1f;
+                gi.Aggro = 0;
+                gi.LifeRegen = 0;
+                gi.JumpSpeedBoost = 0f;
+                gi.RunSpeedBoost = 1f;
+                gi.ArmorPenetration = 0;
+                gi.MinionSlots = 0;
+                gi.SentrySlots = 0;
+                gi.DamageReduction = 0;
+                gi.FlightTime = 0;
+            }   
         }
     }
 }

--- a/Content/Prefixes/Armor/Blessed.cs
+++ b/Content/Prefixes/Armor/Blessed.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().CritDamage = 1.025f;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.CritDamage = 1.025f;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Bulky.cs
+++ b/Content/Prefixes/Armor/Bulky.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().FlightTime = 30;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.FlightTime = 30;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Casters.cs
+++ b/Content/Prefixes/Armor/Casters.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().MinionSlots = 1;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.MinionSlots = 1;
+            }
         }
 
         public override string Name => "Caster's";

--- a/Content/Prefixes/Armor/Defenders.cs
+++ b/Content/Prefixes/Armor/Defenders.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().SentrySlots = 1;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.SentrySlots = 1;
+            }
         }
 
         public override string Name => "Defender's";

--- a/Content/Prefixes/Armor/Divine.cs
+++ b/Content/Prefixes/Armor/Divine.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().LifeRegen = 2;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.LifeRegen = 2;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Escalating.cs
+++ b/Content/Prefixes/Armor/Escalating.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().RunSpeedBoost = 1.25f;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.RunSpeedBoost = 1.25f;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Exalted.cs
+++ b/Content/Prefixes/Armor/Exalted.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().CritDamage = 1.05f;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.CritDamage = 1.05f;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Fortified.cs
+++ b/Content/Prefixes/Armor/Fortified.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().DamageReduction = 8;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.DamageReduction = 8;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Hearty.cs
+++ b/Content/Prefixes/Armor/Hearty.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().MaxHP = 15;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.MaxHP = 15;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Holy.cs
+++ b/Content/Prefixes/Armor/Holy.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().LifeRegen = 1;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.LifeRegen = 1;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Leaping.cs
+++ b/Content/Prefixes/Armor/Leaping.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().JumpSpeedBoost = 1.5f;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.JumpSpeedBoost = 1.5f;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Lofty.cs
+++ b/Content/Prefixes/Armor/Lofty.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().DamageReduction = 4;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.DamageReduction = 4;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Piercing.cs
+++ b/Content/Prefixes/Armor/Piercing.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().ArmorPenetration = 2;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.ArmorPenetration = 2;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Seething.cs
+++ b/Content/Prefixes/Armor/Seething.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().Aggro = 250;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.Aggro = 250;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Shattering.cs
+++ b/Content/Prefixes/Armor/Shattering.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().ArmorPenetration = 4;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.ArmorPenetration = 4;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Soaring.cs
+++ b/Content/Prefixes/Armor/Soaring.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().FlightTime = 60;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.FlightTime = 60;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Tranquil.cs
+++ b/Content/Prefixes/Armor/Tranquil.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().Aggro = -250;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.Aggro = -250;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Vaulting.cs
+++ b/Content/Prefixes/Armor/Vaulting.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().JumpSpeedBoost = 0.75f;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.JumpSpeedBoost = 0.75f;
+            }
         }
     }
 }

--- a/Content/Prefixes/Armor/Vital.cs
+++ b/Content/Prefixes/Armor/Vital.cs
@@ -10,8 +10,11 @@ namespace ArmorAndAccessoryPrefixes.Content.Prefixes.Armor {
 
         public override void Apply(Item item) {
             base.Apply(item);
-
-            item.GetGlobalItem<ArmorGlobalItem>().MaxHP = 30;
+            bool gotItem = item.TryGetGlobalItem(out ArmorGlobalItem gi);
+            if (gotItem)
+            {
+                gi.MaxHP = 30;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes crashes if a mod changes from an armor or accessory to something else.